### PR TITLE
Empty price ranges CSS fix

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,18 @@
         span {
             text-align: center;
         }
+        ul#markdown-toc>li>a:only-child,
+        ul#markdown-toc>li:not(:has(ul)) {
+        	display: none;
+        }
+        
+        h3 {
+        	display: none;
+        }
+        
+        h3:has(+div) {
+        	display: block;
+        }
     </style>
 
     <div class="container">


### PR DESCRIPTION
CSS fix for the following known issues:

- Empty price ranges shown when all wishes in range are all hidden or bought
- Similar issue for the boughtlist when no wishes in the range are bought